### PR TITLE
Changed the method of registering providers

### DIFF
--- a/Sources/AnalyticsKit/Provider/AnalyticProviderType.swift
+++ b/Sources/AnalyticsKit/Provider/AnalyticProviderType.swift
@@ -56,3 +56,23 @@ public enum AnalyticProviderType {
         }
     }
 }
+
+// MARK: - Equatable
+
+extension AnalyticProviderType: Equatable {
+    public static func == (lhs: AnalyticProviderType, rhs: AnalyticProviderType) -> Bool {
+        switch (lhs, rhs) {
+        case (.adjust, .adjust),
+             (.amplitude, .amplitude),
+             (.cleverTap, .cleverTap),
+             (.googleAnalytics, .googleAnalytics):
+            return true
+
+        case let (.other(left), .other(right)):
+            return left === right
+
+        default:
+            return false
+        }
+    }
+}

--- a/Sources/AnalyticsKit/Provider/Instances/AmplitudeProvider.swift
+++ b/Sources/AnalyticsKit/Provider/Instances/AmplitudeProvider.swift
@@ -15,6 +15,7 @@ class AmplitudeProvider: ProviderProtocol {
     // MARK: - Properties
     
     private var accountToken: String? = nil
+    private var trackingSessionEventsPermission: Bool?
     var type: AnalyticProviderType = .amplitude
     var pushNotificationCustomExtras: [AnyHashable : Any]?
     
@@ -24,6 +25,8 @@ class AmplitudeProvider: ProviderProtocol {
             Amplitude.instance().adSupportBlock = {
                 ASIdentifierManager.shared().advertisingIdentifier.uuidString
             }
+            
+            Amplitude.instance().trackingSessionEvents = trackingSessionEventsPermission ?? false
         }
     }
     
@@ -74,5 +77,9 @@ class AmplitudeProvider: ProviderProtocol {
         }
         
         Amplitude.instance().logRevenueV2(revenue)
+    }
+    
+    func setTrackingSessionEventsPermission(_ permission: Bool?) {
+        self.trackingSessionEventsPermission = permission
     }
 }

--- a/Sources/AnalyticsKit/Provider/Instances/CleverTapProvider.swift
+++ b/Sources/AnalyticsKit/Provider/Instances/CleverTapProvider.swift
@@ -15,7 +15,7 @@ class CleverTapProvider: NSObject, ProviderProtocol {
     
     private var accountId: String? = nil
     private var accountToken: String? = nil
-    private var isDeviceNetworkInfoReportingEnable: Bool = false
+    private var isDeviceNetworkInfoReportingEnable: Bool?
     var type: AnalyticProviderType = .cleverTap
     var pushNotificationCustomExtras: [AnyHashable : Any]?
     
@@ -26,7 +26,7 @@ class CleverTapProvider: NSObject, ProviderProtocol {
             CleverTap.setCredentialsWithAccountID(accountId, andToken: accountToken)
         }
         CleverTap.autoIntegrate()
-        CleverTap.sharedInstance()?.enableDeviceNetworkInfoReporting(isDeviceNetworkInfoReportingEnable)
+        CleverTap.sharedInstance()?.enableDeviceNetworkInfoReporting(isDeviceNetworkInfoReportingEnable ?? false)
     }
     
     func updateUserInfo(
@@ -46,7 +46,7 @@ class CleverTapProvider: NSObject, ProviderProtocol {
         if let location = location { CleverTap.setLocation(location) }
     }
 
-	func setPushToken(deviceToken: Data) {
+	func setDeviceToken(_ deviceToken: Data) {
         CleverTap.sharedInstance()?.setPushToken(deviceToken)
         CleverTap.sharedInstance()?.setPushNotificationDelegate(self)
     }
@@ -81,7 +81,7 @@ class CleverTapProvider: NSObject, ProviderProtocol {
         completionHandler(pushNotificationCustomExtras)
     }
     
-    func enableDeviceNetworkInfoReporting(_ permission: Bool) {
+    func enableDeviceNetworkInfoReporting(_ permission: Bool?) {
         isDeviceNetworkInfoReportingEnable = permission
     }
 }

--- a/Sources/AnalyticsKit/Provider/Instances/GoogleAnalyticsProvider.swift
+++ b/Sources/AnalyticsKit/Provider/Instances/GoogleAnalyticsProvider.swift
@@ -18,7 +18,7 @@ class GoogleAnalyticsProvider: NSObject, ProviderProtocol {
     
     var type: AnalyticProviderType = .googleAnalytics
     var pushNotificationCustomExtras: [AnyHashable : Any]?
-    var fcmTokenCompletion: ((String) -> Void)?
+    private var pushTokenCompletion: ((String) -> Void)?
     
     // MARK: - Module functions
     
@@ -46,7 +46,7 @@ class GoogleAnalyticsProvider: NSObject, ProviderProtocol {
         }
     }
 
-    func setPushToken(deviceToken: Data) {
+    func setDeviceToken(_ deviceToken: Data) {
         Messaging.messaging().apnsToken = deviceToken
     }
     
@@ -71,8 +71,8 @@ class GoogleAnalyticsProvider: NSObject, ProviderProtocol {
         print("Google Analytics has no analogue of this function")
     }
     
-    func setFCMTokenCompletion(_ completion: @escaping (String) -> Void) {
-        fcmTokenCompletion = completion
+    func setPushTokenCompletion(_ completion: @escaping (String) -> Void) {
+        pushTokenCompletion = completion
     }
     
     func sendEventCrash(with error: Error) {
@@ -88,11 +88,11 @@ class GoogleAnalyticsProvider: NSObject, ProviderProtocol {
     func getAndSaveToken() {
         Messaging.messaging().token { token, error in
             if let error = error {
-                print("FIRMessaging. Error fetching remote instange ID: \(error)")
+                NSLog("[AnalyticsKit/Firebase]. Error fetching remote instange ID: \(error)")
             } else if let token = token {
-                print("FIRMessaging. Remote instance ID token: \(token)")
-                guard let fcmTokenCompletion = self.fcmTokenCompletion else { return }
-                fcmTokenCompletion(token)
+                NSLog("[AnalyticsKit/Firebase]. Remote instance ID token: \(token)")
+                guard let pushTokenCompletion = self.pushTokenCompletion else { return }
+                pushTokenCompletion(token)
             }
         }
     }
@@ -104,7 +104,7 @@ extension GoogleAnalyticsProvider: MessagingDelegate {
         didReceiveRegistrationToken fcmToken: String?
     ) {
         if let fcmToken = fcmToken {
-            guard let fcmTokenCompletion = self.fcmTokenCompletion else { return }
+            guard let fcmTokenCompletion = self.pushTokenCompletion else { return }
             fcmTokenCompletion(fcmToken)
         }
     }

--- a/Sources/AnalyticsKit/Provider/ProviderConfigurationProtocol.swift
+++ b/Sources/AnalyticsKit/Provider/ProviderConfigurationProtocol.swift
@@ -8,10 +8,42 @@
 import Foundation
 
 public enum ProviderSettings {
-    case pushToken(_ token: Data)
-    case accountId(_ id: String)
-    case accountToken(_ token: String)
-    case environment(_ environment: String)
-    case networkReporting(_ isEnable: Bool)
-    case fcmTokenCompletion(_ provider: AnalyticProviderType, _ completion: (String) -> Void)
+    /**
+     Use this case to set up only a `Ajust` provider
+     
+     - Parameters:
+        - accountToken: Your account token (aka API token / key) from Ajust. [More info](https://help.adjust.com/en/article/your-data)
+        - environment: Environment to post the data to (`environment = sandbox` or `environment = production`). If this parameter is not included, the event will be pushed to the production environment. [More info](https://help.adjust.com/en/article/your-data)
+     
+     */
+    case adjustSettings(accountToken: String?, environment: String?)
+    
+    /**
+     Use this case to set up only a `Amplitude` provider
+     
+     - Parameters:
+        - accountToken: Your account token (aka API token / key) from Amplitude. [More info](https://developers.amplitude.com/docs/ios)
+        - enableTrackingSession: Whether to include the standard session start and end events [More info](https://help.amplitude.com/hc/en-us/articles/115002323627-Track-sessions-in-Amplitude)
+     */
+    case amplitudeSettings(accountToken: String?, enableTrackingSession: Bool?)
+    
+    /**
+     Use this case to set up only a `CleverTap` provider
+     
+     - Parameters:
+        - accountId: Your account ID from CleverTap. [Mode info](https://developer.clevertap.com/docs/authentication)
+        - accountToken: Your account token (aka API token / key) from CleverTap. [More info](https://developer.clevertap.com/docs/authentication)
+        - enableNetworkReporting: Enable collection of data subject to GDPR. [More info](https://developer.clevertap.com/docs/sdk-changes-for-gdpr-compliance#section-device-network-information-reporting-in-i-os)
+        - deviceToken: User device token
+     */
+    case cleverTapSettings(accountId: String?, accountToken: String?, enableNetworkReporting: Bool?, deviceToken: Data?)
+    
+    /**
+     Use this case to set up only a `GoogleAnalytics (Firebase)` provider
+     
+     - Parameters:
+        - pushTokenCompletion: The completion handler to handle the token request. [More info](https://firebase.google.com/docs/reference/swift/firebasemessaging/api/reference/Classes/Messaging#/c:objc(cs)FIRMessaging(im)tokenWithCompletion:)
+        - deviceToken: User device token
+     */
+    case googleAnalyticsSettings(pushTokenCompletion: ((String) -> Void)?, deviceToken: Data?)
 }

--- a/Sources/AnalyticsKit/Provider/ProviderProtocol.swift
+++ b/Sources/AnalyticsKit/Provider/ProviderProtocol.swift
@@ -11,7 +11,7 @@ import CoreLocation
 
 // TODO: come up with a universal or other provider configuration!!!
 
-public protocol ProviderProtocol {
+public protocol ProviderProtocol: AnyObject {
     var type: AnalyticProviderType { get set }
     
     var pushNotificationCustomExtras: [AnyHashable : Any]? { get set }
@@ -39,9 +39,9 @@ public protocol ProviderProtocol {
      
      This will associate the device token with the current user to allow push notifications to the user.
      
-     - Parameter deviceToken: device token as returned from application:didRegisterForRemoteNotificationsWithDeviceToken:
+     - Parameter deviceToken: token as returned from application:didRegisterForRemoteNotificationsWithDeviceToken:
      */
-    func setPushToken(deviceToken: Data)
+    func setDeviceToken(_ deviceToken: Data)
     
     /// Configures an account identifier for the provider. As a rule, any provider has such information, which can be found in the documentation of a particular provider.
     /// - Parameter id: An identifier that allows you to associate your analytics provider account with the application.
@@ -55,7 +55,12 @@ public protocol ProviderProtocol {
     func setEnvironment(_ environment: String)
     
     // TODO: Write documentation
-    func setFCMTokenCompletion(_ completion: @escaping (String) -> Void)
+    func setPushTokenCompletion(_ completion: @escaping (String) -> Void)
+    
+    // TODO: Refactoring
+    // Made to preserve the workflow of the BB client, but it seems that it needs some attention / refactoring.
+    // Only Amplitude method
+    func setTrackingSessionEventsPermission(_ permission: Bool?)
     
     /// Calls the provider's own SDK method to send data.
     /// - Parameters:
@@ -92,7 +97,7 @@ public protocol ProviderProtocol {
     /// Use this method to enable device network-related information tracking, including IP address. This reporting is disabled by default.  To re-disable tracking call this method with enabled set to NO.
     /// - Parameters:
     ///   - permission: Whether device network info reporting should be enabled/disabled.
-    func enableDeviceNetworkInfoReporting(_ permission: Bool)
+    func enableDeviceNetworkInfoReporting(_ permission: Bool?)
     
     // TODO: Rename
     // Here a name like "error message" is more appropriate
@@ -115,13 +120,14 @@ extension ProviderProtocol {
     func sendEvent(with params: [AnyHashable : Any], and items: [Any]) { }
     func sendTags(_ tags: [String: AnyHashable]) { }
     func sendEventRevenue(with params: [String: Any]) { }
-    func setPushToken(deviceToken: Data) { }
+    func setDeviceToken(_ deviceToken: Data) { }
     func setAccountId(_ id: String) { }
     func setAccountToken(_ token: String) { }
     func setEnvironment(_ environment: String) { }
-    func setFCMTokenCompletion(_ completion: @escaping (String) -> Void) { }
+    func setPushTokenCompletion(_ completion: @escaping (String) -> Void) { }
+    func setTrackingSessionEventsPermission(_ permission: Bool?) { }
     func handleNotification(with response: UNNotificationResponse, _ completionHandler: @escaping ([AnyHashable : Any]?) -> Void) { }
-    func enableDeviceNetworkInfoReporting(_ permission: Bool) { }
+    func enableDeviceNetworkInfoReporting(_ permission: Bool?) { }
     func sendEventCrash(with error: Error) { }
     func sendEventCrash(with message: String) { }
     func getAndSaveToken() { }

--- a/Sources/AnalyticsKit/Provider/ProviderSettings.swift
+++ b/Sources/AnalyticsKit/Provider/ProviderSettings.swift
@@ -1,5 +1,5 @@
 //
-//  ProviderConfigurationProtocol.swift
+//  ProviderSettings.swift
 //  
 //
 //  Created by Johnnie Walker on 31.08.2021.

--- a/Sources/AnalyticsKit/Service/AnalyticsProtocol.swift
+++ b/Sources/AnalyticsKit/Service/AnalyticsProtocol.swift
@@ -24,17 +24,7 @@ public protocol AnalyticsProtocol {
      
      ### Example
      ```
-     struct AnalyticsService<T: AnalyticsProtocol> {
-         let service: T
-     }
-     
-     class AnalyticsService {
-     
-        func activateAnalytics() {
-            let analytics = DI.container.resolve(AnalyticsService<ClientAnalytics>.self)!
-            analytics.service.register(.cleverTap)
-        }
-     }
+     // TODO: Rewrite the example
      ```
      
      - Parameter provider: A wrapper over providers that allows you to select one of the predefined objects or add a new one.
@@ -51,31 +41,22 @@ public protocol AnalyticsProtocol {
      
      ### Example
      ```
-     struct AnalyticsService<T: AnalyticsProtocol> {
-         let service: T
-     }
-     
-     class AnalyticsService {
-     
-        func activateAnalytics() {
-            let analytics = DI.container.resolve(AnalyticsService<ClientAnalytics>.self)!
-            analytics.service.register(.cleverTap, with [.accountId("XXX-YYY-ZZZ")])
-        }
-     }
+     // TODO: Rewrite the example
      ```
-     
-     - Parameter provider: A wrapper over providers that allows you to select one of the predefined objects or add a new one.
-     - Parameter settings: Settings applied to the provider.
+     - Parameters:
+       - provider: A wrapper over providers that allows you to select one of the predefined objects or add a new one.
+       - settings: Settings applied to the provider.
      */
-    func register(_ provider: AnalyticProviderType, with settings: [ProviderSettings])
+    func register(_ provider: AnalyticProviderType, with settings: ProviderSettings)
     
     // TODO: ⚠️ Add method to configure only one provider
     
     /**
      - Parameters:
-        - settings: Settings applied to the provider.
+       - provider: A wrapper over providers that allows you to select one of the predefined objects or add a new one.
+       - settings: Settings applied to the provider.
      */
-    func applyProvidersSettings(_ settings: [ProviderSettings])
+    func updateSettings(of provider: AnalyticProviderType, by settings: ProviderSettings)
     
     /**
      Tells the provider that a unique user is logged into the application


### PR DESCRIPTION
## Было:

Можно было передать в массив `settings` любое доступное свойство, втч те, с которыми провайдер может работать (example: `pushTokenCompletion` для `cleverTap`)

```
service.register(
    .cleverTap, with: [
        .accountId(cleverTapAccountId),
        .accountToken(cleverTapAccountToken),
        .networkReporting(true)
    ]
)
```

## Стало:

При передаче параметров через associated value однозначно понятно - какие параметры способен принимать тот или иной провайдер

```
public enum ProviderSettings {
    case cleverTapSettings(accountId: String?, accountToken: String?, enableNetworkReporting: Bool?, deviceToken: Data?)
    ...
}

...
service.register(
    .cleverTap,
    with: .cleverTapSettings(
        accountId: cleverTapAccountId,
        accountToken: cleverTapAccountToken,
        enableNetworkReporting: true,
        deviceToken: nil
    )
)
```